### PR TITLE
Fix Windows settings path, Fix VS2022 build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<CONFIGURATION>)
 option(BUILD_SHARED_LIBS OFF "Build static")
 
 if(MSVC)
-  add_definitions(/MP)
+  add_compile_options(/MP)
 endif()
 
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE INTERNAL "")

--- a/source/globals.h
+++ b/source/globals.h
@@ -41,7 +41,10 @@ static const std::string AppVersion = "v1.5";
 #define pclose _pclose
 #define mkdir _mkdir
 #include <wx/wx.h> 
-	static const std::filesystem::path homedir = getenv("HOMEPATH");
+	static const std::filesystem::path homepath = getenv("HOMEPATH");
+	static const std::filesystem::path homedrive = getenv("HOMEDRIVE");
+	static const std::filesystem::path homedir = homedrive / homepath;
+
 	static const std::filesystem::path datapath = homedir / std::filesystem::path("AppData\\Roaming\\UnityHubNative");
 	static const char dirsep = '\\';
 


### PR DESCRIPTION
- Fixes incomplete path to settings in Windows
- Replaces "add_definitions" with "add_compile_options" to fix an error while building with Visual Studio 2022