### PR TITLE
Made save / restore of the main window size and position using wxConfig

### DIFF
--- a/source/interface_derived.cpp
+++ b/source/interface_derived.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <wx/dirdlg.h>
 #include <wx/aboutdlg.h>
+#include <wx/config.h>
 #if defined _WIN32
 #include "dirent.h" 
 #else
@@ -29,6 +30,11 @@ using namespace std::filesystem;
 
 #define LEARN_TAB 2
 #define WEBVIEW 2000
+#define CONFIG_NAME "com.nativeunityhub.config"
+#define SETTING_WIDTH "W_WIDTH"
+#define SETTING_HEIGHT "W_HEIGHT"
+#define SETTING_POSITION_X "POSITION_X"
+#define SETTING_POSITION_Y "POSITION_Y"
 //the web view unloads after 5 minutes of page hidden
 const int TIMER_LENGTH = 5 * 1000 * 60;
 
@@ -74,6 +80,14 @@ wxEND_EVENT_TABLE()
 
 //call superclass constructor
 MainFrameDerived::MainFrameDerived() : MainFrame(NULL){
+    // set saved position and size
+    wxConfig *config = new wxConfig(CONFIG_NAME);
+    int width, height, x, y;
+    if (config->Read(SETTING_WIDTH, &width) && config->Read(SETTING_HEIGHT, &height) &&
+        config->Read(SETTING_POSITION_X, &x) && config->Read(SETTING_POSITION_Y, &y)) {
+        this->SetSize(x, y, width, height);
+    }
+    delete config;
 	//set up project list columns
 	{
 		string cols[] = {"Project Name","Unity Version","Last Modified","Path"};
@@ -107,6 +121,21 @@ MainFrameDerived::MainFrameDerived() : MainFrame(NULL){
 	this->SetLabel(fmt::format("Unity Hub Native {}",AppVersion));
     projSearchCtrl->Bind(wxEVT_KEY_UP, &MainFrameDerived::Filter, this);
 	projSearchCtrl->SetFocus();
+}
+
+void MainFrameDerived::OnQuit(wxCommandEvent&){
+    // save window size and position
+    wxConfig *config = new wxConfig(CONFIG_NAME);
+    int width, height, x, y;
+    this->GetSize(&width, &height);
+    this->GetPosition(&x, &y);
+    config->Write(SETTING_WIDTH, width);
+    config->Write(SETTING_HEIGHT, height);
+    config->Write(SETTING_POSITION_X, x);
+    config->Write(SETTING_POSITION_Y, y);
+    delete config;
+
+    Close();
 }
 
 void MainFrameDerived::OnSelectProject(wxListEvent&){

--- a/source/interface_derived.hpp
+++ b/source/interface_derived.hpp
@@ -49,9 +49,7 @@ private:
     void OnSelectEditor(wxCommandEvent&);
     void OnSelectEditorPath(wxCommandEvent&);
 
-	void OnQuit(wxCommandEvent&) {
-		Close();
-	}
+	void OnQuit(wxCommandEvent&);
     
     wxWindow* const projectActionItems[3]{
         revealProjBtn,


### PR DESCRIPTION
Added a feature to keep main window's size and position, and not reset it on each launch. Used default wxConfig feature already included in project, so no any new tools here.

Tested on Mac, can't test it on Windows or Linux at the time. Sorry if I did something wrong, C++ is not my main language.