### PR TITLE
Fixed some issues, preventing building project on a mac machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,17 +26,7 @@ file(GLOB source "source/*.cpp" "source/*.hpp" "source/*.h")
 if (APPLE)
 	enable_language(C CXX OBJCXX)
 	set(OBJCPP "source/AppleUtilities.h" "source/AppleUtilities.mm")
-    # Detect whether we are on an Intel or ARM Mac
-    execute_process(COMMAND uname -m RESULT_VARIABLE result OUTPUT_VARIABLE OSX_ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(OSX_ARCHITECTURE STREQUAL "x86_64")
-        # Intel architecture
-        set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "")
-    elseif(OSX_ARCHITECTURE STREQUAL "arm64")
-        # Apple Silicon architecture
-        set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE INTERNAL "")
-    else()
-        message(FATAL_ERROR "Unknown architecture: ${OSX_ARCHITECTURE}")
-    endif()
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE INTERNAL "")
 endif()
 add_executable("${PROJECT_NAME}" WIN32 ${source} "source/wxmac.icns" "source/windows.rc" ${OBJCPP})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)   
 
-project("UnityHubNative")
+project("UnityHubNative" LANGUAGES C CXX OBJCXX)
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<CONFIGURATION>)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<CONFIGURATION>)
@@ -26,6 +26,17 @@ message("module path = ${CMAKE_MODULE_PATH}")
 file(GLOB source "source/*.cpp" "source/*.hpp" "source/*.h")
 if (APPLE)
 	set(OBJCPP "source/AppleUtilities.h" "source/AppleUtilities.mm")
+    # Detect whether we are on an Intel or ARM Mac
+    execute_process(COMMAND uname -m RESULT_VARIABLE result OUTPUT_VARIABLE OSX_ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(OSX_ARCHITECTURE STREQUAL "x86_64")
+        # Intel architecture
+        set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "")
+    elseif(OSX_ARCHITECTURE STREQUAL "arm64")
+        # Apple Silicon architecture
+        set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE INTERNAL "")
+    else()
+        message(FATAL_ERROR "Unknown architecture: ${OSX_ARCHITECTURE}")
+    endif()
 endif()
 add_executable("${PROJECT_NAME}" WIN32 ${source} "source/wxmac.icns" "source/windows.rc" ${OBJCPP})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)   
 
-project("UnityHubNative" LANGUAGES C CXX OBJCXX)
+project("UnityHubNative")
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<CONFIGURATION>)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<CONFIGURATION>)
@@ -24,6 +24,7 @@ message("module path = ${CMAKE_MODULE_PATH}")
 
 file(GLOB source "source/*.cpp" "source/*.hpp" "source/*.h")
 if (APPLE)
+	enable_language(C CXX OBJCXX)
 	set(OBJCPP "source/AppleUtilities.h" "source/AppleUtilities.mm")
     # Detect whether we are on an Intel or ARM Mac
     execute_process(COMMAND uname -m RESULT_VARIABLE result OUTPUT_VARIABLE OSX_ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ if(MSVC)
   add_compile_options(/MP)
 endif()
 
-set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)" CACHE INTERNAL "")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE INTERNAL "")
 
 # linux detection

--- a/mbedtls/include/psa/crypto.h
+++ b/mbedtls/include/psa/crypto.h
@@ -89,15 +89,25 @@ extern "C" {
  * seeding of the random number generator.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough runtime memory.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There was not enough persistent storage.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There was not enough entropy to seed the random number generator.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in persistent storage, such as corruption.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         There was invalid data in persistent storage.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         There was corrupt data in persistent storage.
  */
 psa_status_t psa_crypto_init(void);
 
@@ -369,13 +379,21 @@ static size_t psa_get_key_bits(const psa_key_attributes_t *attributes);
  *                              freshly-initialized structure.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in persistent storage, such as corruption.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         There was corrupt data in persistent storage.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         There was invalid data in persistent storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -487,6 +505,7 @@ psa_status_t psa_purge_key(mbedtls_svc_key_id_t key);
  *                          \c 0 on failure.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
  *         \p source_key is invalid.
  * \retval #PSA_ERROR_ALREADY_EXISTS
@@ -506,13 +525,21 @@ psa_status_t psa_purge_key(mbedtls_svc_key_id_t key);
  *         The source key is not exportable and its lifetime does not
  *         allow copying it to the target's lifetime.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There was insufficient storage for the key material.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data is not correctly formatted.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The key data is corrupted.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in persistent storage, such as corruption.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -637,13 +664,21 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key);
  *         The size in \p attributes is nonzero and does not match the size
  *         of the key data.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There was insufficient storage for the key material.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The key data is corrupted.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data is not correctly formatted.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in persistent storage, such as corruption.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -724,10 +759,13 @@ psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
  *                          that make up the key data.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         The key does not have the #PSA_KEY_USAGE_EXPORT flag.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type is not supported.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p data buffer is too small. You can determine a
  *         sufficient buffer size by calling
@@ -735,10 +773,15 @@ psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
  *         where \c type is the key type
  *         and \c bits is the key size in bits.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in persistent storage, such as corruption.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -799,10 +842,13 @@ psa_status_t psa_export_key(mbedtls_svc_key_id_t key,
  *                          that make up the key data.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The key is neither a public key nor a key pair.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type is not supported.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p data buffer is too small. You can determine a
  *         sufficient buffer size by calling
@@ -810,10 +856,15 @@ psa_status_t psa_export_key(mbedtls_svc_key_id_t key,
  *         where \c type is the key type
  *         and \c bits is the key size in bits.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in persistent storage, such as corruption.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -852,13 +903,19 @@ psa_status_t psa_export_public_key(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not a hash algorithm.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p hash_size is too small for the specified hash algorithm.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         \p hash_size is too small
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -891,10 +948,15 @@ psa_status_t psa_hash_compute(psa_algorithm_t alg,
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p input_length or \p hash_length do not match the hash size for \p alg
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -987,9 +1049,13 @@ static psa_hash_operation_t psa_hash_operation_init(void);
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1012,11 +1078,15 @@ psa_status_t psa_hash_setup(psa_hash_operation_t *operation,
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_BAD_STATE
- *         The operation state is not valid (it muct be active).
+ *         The operation state is not valid (it must be active).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1061,9 +1131,13 @@ psa_status_t psa_hash_update(psa_hash_operation_t *operation,
  *         sufficient buffer size by calling #PSA_HASH_LENGTH(\c alg)
  *         where \c alg is the hash algorithm that is calculated.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1103,9 +1177,13 @@ psa_status_t psa_hash_finish(psa_hash_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1132,9 +1210,13 @@ psa_status_t psa_hash_verify(psa_hash_operation_t *operation,
  * \param[in,out] operation     Initialized hash operation.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1158,14 +1240,19 @@ psa_status_t psa_hash_abort(psa_hash_operation_t *operation);
  *                                  It must be initialized but not active.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_BAD_STATE
  *         The \p source_operation state is not valid (it must be active).
  * \retval #PSA_ERROR_BAD_STATE
  *         The \p target_operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1204,7 +1291,9 @@ psa_status_t psa_hash_clone(const psa_hash_operation_t *source_operation,
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_SIGN_MESSAGE flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
@@ -1212,9 +1301,13 @@ psa_status_t psa_hash_clone(const psa_hash_operation_t *source_operation,
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         \p mac_size is too small
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_STORAGE_FAILURE
  *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
@@ -1247,15 +1340,21 @@ psa_status_t psa_mac_compute(mbedtls_svc_key_id_t key,
  *         The MAC of the message was calculated successfully, but it
  *         differs from the expected value.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_VERIFY_MESSAGE flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not a MAC algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the MAC or the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
  *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
@@ -1352,15 +1451,21 @@ static psa_mac_operation_t psa_mac_operation_init(void);
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_SIGN_MESSAGE flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not a MAC algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the MAC or the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
  *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
@@ -1415,15 +1520,21 @@ psa_status_t psa_mac_sign_setup(psa_mac_operation_t *operation,
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_VERIFY_MESSAGE flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \c key is not compatible with \c alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \c alg is not supported or is not a MAC algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the MAC or the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
  *         The key could not be retrieved from storage
  * \retval #PSA_ERROR_BAD_STATE
@@ -1455,10 +1566,15 @@ psa_status_t psa_mac_verify_setup(psa_mac_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the MAC or the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1505,10 +1621,15 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
  *         The size of the \p mac buffer is too small. You can determine a
  *         sufficient buffer size by calling PSA_MAC_LENGTH().
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the MAC or the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1549,10 +1670,15 @@ psa_status_t psa_mac_sign_finish(psa_mac_operation_t *operation,
  *         The operation state is not valid (it must be an active mac verify
  *         operation).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the MAC or the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1579,9 +1705,13 @@ psa_status_t psa_mac_verify_finish(psa_mac_operation_t *operation,
  * \param[in,out] operation Initialized MAC operation.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the MAC or the key material.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1618,17 +1748,25 @@ psa_status_t psa_mac_abort(psa_mac_operation_t *operation);
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_ENCRYPT flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not a cipher algorithm.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
+ *         \p output_size is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1665,17 +1803,25 @@ psa_status_t psa_cipher_encrypt(mbedtls_svc_key_id_t key,
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_DECRYPT flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not a cipher algorithm.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
+ *         \p output_size is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1772,16 +1918,23 @@ static psa_cipher_operation_t psa_cipher_operation_init(void);
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_ENCRYPT flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not a cipher algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_BAD_STATE
@@ -1836,16 +1989,23 @@ psa_status_t psa_cipher_encrypt_setup(psa_cipher_operation_t *operation,
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_DECRYPT flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not a cipher algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_BAD_STATE
@@ -1882,10 +2042,15 @@ psa_status_t psa_cipher_decrypt_setup(psa_cipher_operation_t *operation,
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p iv buffer is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to generate the IV.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while generating the IV.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while generating the IV.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while generating the IV.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while generating the IV.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1924,10 +2089,15 @@ psa_status_t psa_cipher_generate_iv(psa_cipher_operation_t *operation,
  *         The size of \p iv is not acceptable for the chosen algorithm,
  *         or the chosen algorithm does not use an IV.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to set the IV.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while setting the IV.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while setting the IV.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while setting the IV.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while setting the IV.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1966,10 +2136,15 @@ psa_status_t psa_cipher_set_iv(psa_cipher_operation_t *operation,
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2019,10 +2194,15 @@ psa_status_t psa_cipher_update(psa_cipher_operation_t *operation,
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2050,9 +2230,13 @@ psa_status_t psa_cipher_finish(psa_cipher_operation_t *operation,
  * \param[in,out] operation     Initialized cipher operation.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the cipher operation or the key.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2106,12 +2290,15 @@ psa_status_t psa_cipher_abort(psa_cipher_operation_t *operation);
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_ENCRYPT flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not an AEAD algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         \p ciphertext_size is too small.
  *         #PSA_AEAD_ENCRYPT_OUTPUT_SIZE(\c key_type, \p alg,
@@ -2119,9 +2306,13 @@ psa_status_t psa_cipher_abort(psa_cipher_operation_t *operation);
  *         #PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(\p plaintext_length) can be used to
  *         determine the required buffer size.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2177,14 +2368,17 @@ psa_status_t psa_aead_encrypt(mbedtls_svc_key_id_t key,
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_INVALID_SIGNATURE
  *         The ciphertext is not authentic.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_DECRYPT flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not an AEAD algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         \p plaintext_size is too small.
  *         #PSA_AEAD_DECRYPT_OUTPUT_SIZE(\c key_type, \p alg,
@@ -2192,9 +2386,13 @@ psa_status_t psa_aead_encrypt(mbedtls_svc_key_id_t key,
  *         #PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE(\p ciphertext_length) can be used
  *         to determine the required buffer size.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the key material or the
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2303,16 +2501,23 @@ static psa_aead_operation_t psa_aead_operation_init(void);
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_ENCRYPT flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not an AEAD algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2370,16 +2575,23 @@ psa_status_t psa_aead_encrypt_setup(psa_aead_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_DECRYPT flag.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported or is not an AEAD algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory for the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected in the key material.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2416,10 +2628,15 @@ psa_status_t psa_aead_decrypt_setup(psa_aead_operation_t *operation,
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p nonce buffer is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to generate the nonce.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while generating the nonce.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while generating the nonce.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while generating the nonce.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while generating the nonce.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2457,10 +2674,15 @@ psa_status_t psa_aead_generate_nonce(psa_aead_operation_t *operation,
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The size of \p nonce is not acceptable for the chosen algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to set the nonce.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while setting the nonce.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while setting the nonce.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while setting the nonce.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while setting the nonce.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2504,9 +2726,13 @@ psa_status_t psa_aead_set_nonce(psa_aead_operation_t *operation,
  *         At least one of the lengths is not acceptable for the chosen
  *         algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to set the lengths.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while setting the lengths.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while setting the lengths.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while setting the lengths.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2552,10 +2778,15 @@ psa_status_t psa_aead_set_lengths(psa_aead_operation_t *operation,
  *         The total input length overflows the additional data length that
  *         was previously specified with psa_aead_set_lengths().
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to process the additional data.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while processing the additional data.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while processing the additional data.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while processing the additional data.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while processing the additional data.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2638,10 +2869,15 @@ psa_status_t psa_aead_update_ad(psa_aead_operation_t *operation,
  *         The total input length overflows the plaintext length that
  *         was previously specified with psa_aead_set_lengths().
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to process the message fragment.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while processing the message fragment.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while processing the message fragment.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while processing the message fragment.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while processing the message fragment.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2726,10 +2962,15 @@ psa_status_t psa_aead_update(psa_aead_operation_t *operation,
  *         less than the plaintext length that was previously
  *         specified with psa_aead_set_lengths().
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to finish the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while finishing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while finishing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while finishing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while finishing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2811,10 +3052,15 @@ psa_status_t psa_aead_finish(psa_aead_operation_t *operation,
  *         less than the plaintext length that was previously
  *         specified with psa_aead_set_lengths().
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to finish the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while finishing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while finishing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while finishing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while finishing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2844,9 +3090,13 @@ psa_status_t psa_aead_verify(psa_aead_operation_t *operation,
  * \param[in,out] operation     Initialized AEAD operation.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while aborting the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while aborting the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while aborting the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2893,7 +3143,9 @@ psa_status_t psa_aead_abort(psa_aead_operation_t *operation);
  *                              the returned signature value.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         The key does not have the #PSA_KEY_USAGE_SIGN_MESSAGE flag,
  *         or it does not permit the requested algorithm.
@@ -2904,15 +3156,25 @@ psa_status_t psa_aead_abort(psa_aead_operation_t *operation);
  *         where \c key_type and \c key_bits are the type and bit-size
  *         respectively of \p key.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p alg is not supported or is not a signature algorithm.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         There was a corruption in the input data.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The input data was not formatted correctly or did not match the key.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is insufficient entropy to generate random data needed for the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -2949,7 +3211,9 @@ psa_status_t psa_sign_message( mbedtls_svc_key_id_t key,
  * \param[in]  signature_length Size of the \p signature buffer in bytes.
  *
  * \retval #PSA_SUCCESS
+ *         The signature is valid.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         The key does not have the #PSA_KEY_USAGE_SIGN_MESSAGE flag,
  *         or it does not permit the requested algorithm.
@@ -2957,14 +3221,23 @@ psa_status_t psa_sign_message( mbedtls_svc_key_id_t key,
  *         The calculation was performed successfully, but the passed signature
  *         is not a valid signature.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p alg is not supported or is not a signature algorithm.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         There was a corruption in the input data.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The input data was not formatted correctly or did not match the key.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3002,8 +3275,12 @@ psa_status_t psa_verify_message( mbedtls_svc_key_id_t key,
  *                              that make up the returned signature value.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_SIGN_HASH flag,
+ *         or it does not permit the requested algorithm.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p signature buffer is too small. You can
  *         determine a sufficient buffer size by calling
@@ -3011,13 +3288,21 @@ psa_status_t psa_verify_message( mbedtls_svc_key_id_t key,
  *         where \c key_type and \c key_bits are the type and bit-size
  *         respectively of \p key.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p alg is not supported or is not a signature algorithm.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is insufficient entropy to generate random data needed for the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3058,17 +3343,27 @@ psa_status_t psa_sign_hash(mbedtls_svc_key_id_t key,
  * \retval #PSA_SUCCESS
  *         The signature is valid.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_VERIFY_HASH flag,
+ *         or it does not permit the requested algorithm.
  * \retval #PSA_ERROR_INVALID_SIGNATURE
  *         The calculation was perfomed successfully, but the passed
  *         signature is not a valid signature.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p alg is not supported or is not a signature algorithm.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3111,8 +3406,12 @@ psa_status_t psa_verify_hash(mbedtls_svc_key_id_t key,
  *                              that make up the returned output.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_ENCRYPT flag,
+ *         or it does not permit the requested algorithm.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small. You can
  *         determine a sufficient buffer size by calling
@@ -3120,13 +3419,21 @@ psa_status_t psa_verify_hash(mbedtls_svc_key_id_t key,
  *         where \c key_type and \c key_bits are the type and bit-size
  *         respectively of \p key.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p alg is not supported or is not an encryption algorithm.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is insufficient entropy to generate random data needed for the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3171,8 +3478,12 @@ psa_status_t psa_asymmetric_encrypt(mbedtls_svc_key_id_t key,
  *                              that make up the returned output.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_DECRYPT flag,
+ *         or it does not permit the requested algorithm.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small. You can
  *         determine a sufficient buffer size by calling
@@ -3180,14 +3491,23 @@ psa_status_t psa_asymmetric_encrypt(mbedtls_svc_key_id_t key,
  *         where \c key_type and \c key_bits are the type and bit-size
  *         respectively of \p key.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p alg is not supported or is not an encryption algorithm.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key is not compatible with \p alg.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is insufficient entropy to generate random data needed for the operation.
  * \retval #PSA_ERROR_INVALID_PADDING
+ *         The message could not be decrypted because the padding was invalid.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3298,10 +3618,15 @@ static psa_key_derivation_operation_t psa_key_derivation_operation_init(void);
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \c alg is not supported or is not a key derivation algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_BAD_STATE
@@ -3323,11 +3648,15 @@ psa_status_t psa_key_derivation_setup(
  * \param[out] capacity     On success, the capacity of the operation.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while querying the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active).
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while querying the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while querying the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3348,6 +3677,7 @@ psa_status_t psa_key_derivation_get_capacity(
  *                          current capacity.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p capacity is larger than the operation's current capacity.
  *         In this case, the operation object remains valid and its capacity
@@ -3355,8 +3685,11 @@ psa_status_t psa_key_derivation_get_capacity(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active).
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while setting the capacity.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while setting the capacity.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while setting the capacity.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3406,10 +3739,15 @@ psa_status_t psa_key_derivation_set_capacity(
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \c step does not allow direct inputs.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid for this input \p step.
  * \retval #PSA_ERROR_BAD_STATE
@@ -3451,10 +3789,15 @@ psa_status_t psa_key_derivation_input_bytes(
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \c step does not allow numeric inputs.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid for this input \p step.
  * \retval #PSA_ERROR_BAD_STATE
@@ -3510,6 +3853,7 @@ psa_status_t psa_key_derivation_input_integer(
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \c key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         The key allows neither #PSA_KEY_USAGE_DERIVE nor
  *         #PSA_KEY_USAGE_VERIFY_DERIVATION, or it doesn't allow this
@@ -3520,10 +3864,15 @@ psa_status_t psa_key_derivation_input_integer(
  *         \c step does not allow key inputs of the given type
  *         or does not allow key inputs at all.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid for this input \p step.
  * \retval #PSA_ERROR_BAD_STATE
@@ -3582,7 +3931,9 @@ psa_status_t psa_key_derivation_input_key(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid for this key agreement \p step.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \c private_key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         \c private_key does not allow the usage #PSA_KEY_USAGE_DERIVE.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \c private_key is not compatible with \c alg,
  *         or \p peer_key is not valid for \c alg or not compatible with
@@ -3592,10 +3943,15 @@ psa_status_t psa_key_derivation_input_key(
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \c step does not allow an input resulting from a key agreement.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3626,6 +3982,7 @@ psa_status_t psa_key_derivation_key_agreement(
  * \param output_length     Number of bytes to output.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         One of the inputs was a key whose policy didn't allow
  *         #PSA_KEY_USAGE_DERIVE.
@@ -3640,10 +3997,15 @@ psa_status_t psa_key_derivation_key_agreement(
  *         The operation state is not valid (it must be active and completed
  *         all required input steps).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3788,13 +4150,23 @@ psa_status_t psa_key_derivation_output_bytes(
  *         The operation state is not valid (it must be active and completed
  *         all required input steps).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There was insufficient storage space on the device to store the
+ *         key persistently.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key derivation operation produced an invalid key material.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The key derivation operation produced key material that does not
+ *         match the key type.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3834,6 +4206,8 @@ psa_status_t psa_key_derivation_output_key(
  *                          number of bytes that will be read.
  *
  * \retval #PSA_SUCCESS
+ *         The output was read successfully, and it matches the expected
+ *         output.
  * \retval #PSA_ERROR_INVALID_SIGNATURE
  *         The output was read successfully, but it differs from the expected
  *         output.
@@ -3850,10 +4224,15 @@ psa_status_t psa_key_derivation_output_key(
  *         The operation state is not valid (it must be active and completed
  *         all required input steps).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3894,6 +4273,8 @@ psa_status_t psa_key_derivation_verify_bytes(
  *                          psa_key_derivation_output_key().
  *
  * \retval #PSA_SUCCESS
+ *         The output was read successfully, and it matches the expected
+ *         output.
  * \retval #PSA_ERROR_INVALID_SIGNATURE
  *         The output was read successfully, but if differs from the expected
  *         output.
@@ -3906,19 +4287,24 @@ psa_status_t psa_key_derivation_verify_bytes(
  *         this algorithm; or one of the inputs was a key whose policy didn't
  *         allow #PSA_KEY_USAGE_VERIFY_DERIVATION.
  * \retval #PSA_ERROR_INSUFFICIENT_DATA
- *                          The operation's capacity was less than
- *                          the length of the expected value. In this case,
- *                          the operation's capacity is set to 0, thus
- *                          subsequent calls to this function will not
- *                          succeed, even with a smaller expected output.
+ *         The operation's capacity was less than
+ *         the length of the expected value. In this case,
+ *         the operation's capacity is set to 0, thus
+ *         subsequent calls to this function will not
+ *         succeed, even with a smaller expected output.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active and completed
  *         all required input steps).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3943,9 +4329,13 @@ psa_status_t psa_key_derivation_verify_key(
  * \param[in,out] operation    The operation to abort.
  *
  * \retval #PSA_SUCCESS
+ *         The operation was aborted.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -3984,7 +4374,9 @@ psa_status_t psa_key_derivation_abort(
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p private_key is not a valid identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         \p private_key does not allow the usage #PSA_KEY_USAGE_DERIVE.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p alg is not a key agreement algorithm
  * \retval #PSA_ERROR_INVALID_ARGUMENT
@@ -3996,10 +4388,16 @@ psa_status_t psa_key_derivation_abort(
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not a supported key agreement algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the
+ *         operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -4032,12 +4430,23 @@ psa_status_t psa_raw_key_agreement(psa_algorithm_t alg,
  * \param output_size       Number of bytes to generate and output.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The requested random generation operation is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is not enough entropy to generate random data of the
+ *         requested size. The implementation may be able to generate
+ *         smaller data. Callers who encounter this error should consider
+ *         calling this function again to generate smaller data.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the
+ *         operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -4075,16 +4484,35 @@ psa_status_t psa_generate_random(uint8_t *output,
  *         This is an attempt to create a persistent key, and there is
  *         already a persistent key with the given identifier.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type or key size is not supported, either by the
+ *         implementation in general or in this particular location.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The provided key attributes are not valid for the implementation.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is not enough entropy to generate a random key of the
+ *         requested size. The implementation may be able to generate
+ *         smaller keys. Callers who encounter this error should consider
+ *         calling this function again to generate a smaller key.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure while performing the operation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the hardware while performing the
+ *         operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption detected while performing the operation.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There was insufficient storage space on the device to store the
+ *         key persistently.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key material or metadata produced by the implementation was
+ *         invalid and could not be stored.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The key material or metadata produced by the implementation was
+ *         corrupt and could not be stored.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure while performing the operation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize

--- a/mbedtls/include/psa/crypto_compat.h
+++ b/mbedtls/include/psa/crypto_compat.h
@@ -106,10 +106,16 @@ static inline int psa_key_handle_is_null( psa_key_handle_t handle )
  *         define any way to create such a key, but it may be possible
  *         through implementation-specific means.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure inside the implementation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption failure inside the implementation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure that prevented the implementation from
+ *         accessing the key.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data was corrupted.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The key data was invalid.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -150,7 +156,9 @@ psa_status_t psa_open_key( mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_INVALID_HANDLE
  *         \p handle is not a valid handle nor \c 0.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure inside the implementation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption failure inside the implementation.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize

--- a/mbedtls/include/psa/crypto_extra.h
+++ b/mbedtls/include/psa/crypto_extra.h
@@ -192,11 +192,17 @@ static inline void psa_clear_key_slot_number(
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         The caller is not authorized to register the specified key slot.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There is not enough memory to register the key.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There is not enough storage to register the key.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a failure in communication with the secure element.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data is not valid.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The key data is corrupted.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key data has been corrupted.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -495,9 +501,15 @@ psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
  * \param data_length           Size of the \p data buffer in bytes.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p type is not a supported key type, or the key type does not
+ *         support domain parameters, or the domain parameters are not
+ *         valid for the key type.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type does not support domain parameters.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to store the domain parameters.
  */
 psa_status_t psa_set_key_domain_parameters(psa_key_attributes_t *attributes,
                                            psa_key_type_t type,
@@ -525,7 +537,10 @@ psa_status_t psa_set_key_domain_parameters(psa_key_attributes_t *attributes,
  *                              that make up the key domain parameters data.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
+ *         \p data_size is too small. You can determine a sufficient buffer
+ *         size by calling PSA_KEY_DOMAIN_PARAMETERS_SIZE().
  */
 psa_status_t psa_get_key_domain_parameters(
     const psa_key_attributes_t *attributes,
@@ -1354,8 +1369,12 @@ static psa_pake_operation_t psa_pake_operation_init(void);
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         The \p cipher_suite is not supported or is not valid.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         Communication with the peer failed.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         A failure of the random generator hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The implementation detected a potential corruption of its internal
+ *         data structures.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1389,11 +1408,18 @@ psa_status_t psa_pake_setup(psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must have been set up.)
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The implementation detected a potential corruption of its internal
+ *         data structures.
  * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p password is not a valid key identifier.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         Communication with the key store failed.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         A failure of the key store hardware.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         Storage failure preventing the key from being retrieved.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key policy does not allow the requested operation.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p key is not compatible with the algorithm or the cipher suite.
  * \retval #PSA_ERROR_BAD_STATE
@@ -1430,9 +1456,14 @@ psa_status_t psa_pake_set_password_key(psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         Communication with the peer failed.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         A failure of the random generator hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The implementation detected a potential corruption of its internal
+ *         data structures.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p user_id is NULL.
  * \retval #PSA_ERROR_BAD_STATE
@@ -1472,9 +1503,14 @@ psa_status_t psa_pake_set_user(psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         The algorithm doesn't associate a second identity with the session.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         Communication with the peer failed.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         A failure of the random generator hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The implementation detected a potential corruption of its internal
+ *         data structures.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         \p user_id is NULL.
  * \retval #PSA_ERROR_BAD_STATE
@@ -1515,8 +1551,12 @@ psa_status_t psa_pake_set_peer(psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         The \p side for this algorithm is not supported or is not valid.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         Communication with the peer failed.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         A failure of the random generator hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The implementation detected a potential corruption of its internal
+ *         data structures.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1562,10 +1602,16 @@ psa_status_t psa_pake_set_side(psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         Communication with the peer failed.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         A failure of the random generator hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The implementation detected a potential corruption of its internal
+ *         data structures.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         Storage failure preventing the key from being retrieved.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
@@ -1606,10 +1652,16 @@ psa_status_t psa_pake_output(psa_pake_operation_t *operation,
  *         The operation state is not valid (it must be active, but beyond that
  *         validity is specific to the algorithm).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         Communication with the peer failed.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         A failure of the random generator hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The implementation detected a potential corruption of its internal
+ *         data structures.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         Storage failure preventing the key from being retrieved.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The input is not valid for the algorithm, ciphersuite or \p step.
  * \retval #PSA_ERROR_BAD_STATE
@@ -1669,10 +1721,16 @@ psa_status_t psa_pake_input(psa_pake_operation_t *operation,
  *         #PSA_KEY_DERIVATION_INPUT_SECRET is not compatible with the output’s
  *         algorithm.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         Communication with the peer failed.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         A failure of the random generator hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The implementation detected a potential corruption of its internal
+ *         data structures.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         Storage failure preventing the key from being retrieved.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize

--- a/mbedtls/include/psa/crypto_se_driver.h
+++ b/mbedtls/include/psa/crypto_se_driver.h
@@ -386,7 +386,9 @@ typedef struct {
  *                              or decrypt
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The requested algorithm is not supported.
  */
 typedef psa_status_t (*psa_drv_se_cipher_setup_t)(psa_drv_se_context_t *drv_context,
                                                   void *op_context,
@@ -408,6 +410,7 @@ typedef psa_status_t (*psa_drv_se_cipher_setup_t)(psa_drv_se_context_t *drv_cont
  * \param[in] iv_length         The size (in bytes) of the `p_iv` buffer
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_cipher_set_iv_t)(void *op_context,
                                                    const uint8_t *p_iv,
@@ -430,6 +433,7 @@ typedef psa_status_t (*psa_drv_se_cipher_set_iv_t)(void *op_context,
  *                                  of bytes placed in the `p_output` buffer
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_cipher_update_t)(void *op_context,
                                                    const uint8_t *p_input,
@@ -451,6 +455,7 @@ typedef psa_status_t (*psa_drv_se_cipher_update_t)(void *op_context,
  *                              bytes placed in the `p_output` buffer
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_cipher_finish_t)(void *op_context,
                                                    uint8_t *p_output,
@@ -486,7 +491,9 @@ typedef psa_status_t (*psa_drv_se_cipher_abort_t)(void *op_context);
  *                              buffer
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The requested algorithm is not supported.
  */
 typedef psa_status_t (*psa_drv_se_cipher_ecb_t)(psa_drv_se_context_t *drv_context,
                                                 psa_key_slot_number_t key_slot,
@@ -555,6 +562,7 @@ typedef struct {
  *                                  that make up the returned signature value
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_asymmetric_sign_t)(psa_drv_se_context_t *drv_context,
                                                      psa_key_slot_number_t key_slot,
@@ -619,6 +627,7 @@ typedef psa_status_t (*psa_drv_se_asymmetric_verify_t)(psa_drv_se_context_t *drv
  *                              the returned output
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_asymmetric_encrypt_t)(psa_drv_se_context_t *drv_context,
                                                         psa_key_slot_number_t key_slot,
@@ -659,6 +668,7 @@ typedef psa_status_t (*psa_drv_se_asymmetric_encrypt_t)(psa_drv_se_context_t *dr
  *                              that make up the returned output
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_asymmetric_decrypt_t)(psa_drv_se_context_t *drv_context,
                                                         psa_key_slot_number_t key_slot,
@@ -906,7 +916,9 @@ typedef enum
  *         The core will record \c *key_slot as the key slot where the key
  *         is stored and will update the persistent data in storage.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The requested key type is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There is not enough storage space for this key.
  */
 typedef psa_status_t (*psa_drv_se_allocate_key_t)(
     psa_drv_se_context_t *drv_context,
@@ -1045,12 +1057,19 @@ typedef psa_status_t (*psa_drv_se_destroy_key_t)(
  *                              that make up the key data.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_DOES_NOT_EXIST
+ *         The specified slot is not currently in use.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The specified slot is not an external key slot.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified key type is not supported.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure with the secure element.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the secure element.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption failure in the secure element.
  */
 typedef psa_status_t (*psa_drv_se_export_key_t)(psa_drv_se_context_t *drv_context,
                                                 psa_key_slot_number_t key,
@@ -1198,6 +1217,7 @@ typedef struct {
  *                              the key derivation
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_key_derivation_setup_t)(psa_drv_se_context_t *drv_context,
                                                           void *op_context,
@@ -1218,6 +1238,7 @@ typedef psa_status_t (*psa_drv_se_key_derivation_setup_t)(psa_drv_se_context_t *
  * \param[in] collateral_size   The size in bytes of the collateral
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_key_derivation_collateral_t)(void *op_context,
                                                                uint32_t collateral_id,
@@ -1232,7 +1253,7 @@ typedef psa_status_t (*psa_drv_se_key_derivation_collateral_t)(void *op_context,
  * \param[in] dest_key          The slot where the generated key material
  *                              should be placed
  *
- * \retval #PSA_SUCCESS
+ * \retval #PSA_SUCCESS         Success.
  */
 typedef psa_status_t (*psa_drv_se_key_derivation_derive_t)(void *op_context,
                                                           psa_key_slot_number_t dest_key);
@@ -1247,6 +1268,7 @@ typedef psa_status_t (*psa_drv_se_key_derivation_derive_t)(void *op_context,
  *                              key material placed in `p_output`
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  */
 typedef psa_status_t (*psa_drv_se_key_derivation_export_t)(void *op_context,
                                                            uint8_t *p_output,

--- a/mbedtls/library/bignum.c
+++ b/mbedtls/library/bignum.c
@@ -1392,7 +1392,7 @@ void mpi_mul_hlp( size_t i,
                   mbedtls_mpi_uint *d,
                   mbedtls_mpi_uint b )
 {
-    mbedtls_mpi_uint c = 0, t = 0;
+    mbedtls_mpi_uint c = 0;
 
 #if defined(MULADDC_HUIT)
     for( ; i >= 8; i -= 8 )
@@ -1442,8 +1442,6 @@ void mpi_mul_hlp( size_t i,
         MULADDC_STOP
     }
 #endif /* MULADDC_HUIT */
-
-    t++;
 
     while( c != 0 )
     {

--- a/mbedtls/library/psa_crypto.c
+++ b/mbedtls/library/psa_crypto.c
@@ -1684,11 +1684,18 @@ static psa_status_t psa_start_key_creation(
  * \retval #PSA_SUCCESS
  *         The key was successfully created.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough storage space to create the key.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There was not enough storage space to create the key.
  * \retval #PSA_ERROR_ALREADY_EXISTS
+ *         There is already a key with this identifier.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data is not valid.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         There was an inconsistency between volatile and non-volatile
+ *         storage.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in persistent storage.
  *
  * \return If this function fails, the key slot is an invalid state.
  *         You must call psa_fail_key_creation() to wipe and free the slot.

--- a/mbedtls/library/psa_crypto_aead.h
+++ b/mbedtls/library/psa_crypto_aead.h
@@ -68,13 +68,17 @@
  * \param[out] ciphertext_length  On success, the size of the output in the
  *                                ciphertext buffer.
  *
- * \retval #PSA_SUCCESS Success.
+ * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         Failed to allocate memory for key material
+ *         or for a temporary buffer.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         ciphertext_size is too small.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The cipher is not authentic.
  */
 psa_status_t mbedtls_psa_aead_encrypt(
     const psa_key_attributes_t *attributes,
@@ -129,15 +133,19 @@ psa_status_t mbedtls_psa_aead_encrypt(
  * \param[out] plaintext_length   On success, the size of the output in the
  *                                plaintext buffer.
  *
- * \retval #PSA_SUCCESS Success.
+ * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_SIGNATURE
  *         The cipher is not authentic.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         Failed to allocate memory for key material
+ *         or for a temporary buffer.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         plaintext_size is too small.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The cipher is not authentic.
  */
 psa_status_t mbedtls_psa_aead_decrypt(
     const psa_key_attributes_t *attributes,

--- a/mbedtls/library/psa_crypto_cipher.h
+++ b/mbedtls/library/psa_crypto_cipher.h
@@ -60,9 +60,13 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_psa(
  *                              #PSA_ALG_IS_CIPHER(\p alg) is true).
  *
  * \retval #PSA_SUCCESS
+ *         The operation has been initialized successfully.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported or is not a cipher.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal error in the implementation.
  */
 psa_status_t mbedtls_psa_cipher_encrypt_setup(
     mbedtls_psa_cipher_operation_t *operation,
@@ -90,9 +94,13 @@ psa_status_t mbedtls_psa_cipher_encrypt_setup(
  *                              #PSA_ALG_IS_CIPHER(\p alg) is true).
  *
  * \retval #PSA_SUCCESS
+ *         The operation has been initialized successfully.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported or is not a cipher.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal error in the implementation.
  */
 psa_status_t mbedtls_psa_cipher_decrypt_setup(
     mbedtls_psa_cipher_operation_t *operation,
@@ -117,10 +125,12 @@ psa_status_t mbedtls_psa_cipher_decrypt_setup(
  *                              PSA_CIPHER_IV_MAX_SIZE.
  *
  * \retval #PSA_SUCCESS
+ *         The IV has been successfully set.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The size of \p iv is not acceptable for the chosen algorithm,
  *         or the chosen algorithm does not use an IV.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory to perform the operation.
  */
 psa_status_t mbedtls_psa_cipher_set_iv(
     mbedtls_psa_cipher_operation_t *operation,
@@ -143,9 +153,11 @@ psa_status_t mbedtls_psa_cipher_set_iv(
  *                              that make up the returned output.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory to perform the operation.
  */
 psa_status_t mbedtls_psa_cipher_update(
     mbedtls_psa_cipher_operation_t *operation,
@@ -166,6 +178,7 @@ psa_status_t mbedtls_psa_cipher_update(
  *                              that make up the returned output.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The total input size passed to this operation is not valid for
  *         this particular algorithm. For example, the algorithm is a based
@@ -177,6 +190,7 @@ psa_status_t mbedtls_psa_cipher_update(
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory to perform the operation.
  */
 psa_status_t mbedtls_psa_cipher_finish(
     mbedtls_psa_cipher_operation_t *operation,
@@ -195,7 +209,7 @@ psa_status_t mbedtls_psa_cipher_finish(
  *
  * \param[in,out] operation     Initialized cipher operation.
  *
- * \retval #PSA_SUCCESS
+ * \retval #PSA_SUCCESS         Success.
  */
 psa_status_t mbedtls_psa_cipher_abort( mbedtls_psa_cipher_operation_t *operation );
 
@@ -225,9 +239,13 @@ psa_status_t mbedtls_psa_cipher_abort( mbedtls_psa_cipher_operation_t *operation
  *                              by the core.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported or is not a cipher.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal error in the implementation.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
@@ -276,9 +294,13 @@ psa_status_t mbedtls_psa_cipher_encrypt( const psa_key_attributes_t *attributes,
  *                              by the core.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported or is not a cipher.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal error in the implementation.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small.
  * \retval #PSA_ERROR_INVALID_ARGUMENT

--- a/mbedtls/library/psa_crypto_core.h
+++ b/mbedtls/library/psa_crypto_core.h
@@ -193,6 +193,8 @@ static inline psa_key_slot_number_t psa_key_slot_get_slot_number(
  *         Success. This includes the case of a key slot that was
  *         already fully wiped.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key slot was not fully wiped because the key data was
+ *         corrupted.
  */
 psa_status_t psa_wipe_key_slot( psa_key_slot_t *slot );
 
@@ -281,12 +283,16 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_psa(
  *                                key_buffer in bytes.
  * \param[out] bits             The key size in number of bits.
  *
- * \retval #PSA_SUCCESS  The key was imported successfully.
+ * \retval #PSA_SUCCESS
+ *         The key was imported successfully.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The key data is not correctly formatted.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key data was corrupted.
  */
 psa_status_t psa_import_key_into_slot(
     const psa_key_attributes_t *attributes,
@@ -308,13 +314,21 @@ psa_status_t psa_import_key_into_slot(
  * \param[out] data_length      On success, the number of bytes written in
  *                              \p data
  *
- * \retval #PSA_SUCCESS  The key was exported successfully.
+ * \retval #PSA_SUCCESS
+ *         The key was exported successfully.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type is not supported.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure inside the implementation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the underlying hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key data was corrupted.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure that prevented the implementation from
+ *         exporting the key.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  */
 psa_status_t psa_export_key_internal(
     const psa_key_attributes_t *attributes,
@@ -336,13 +350,21 @@ psa_status_t psa_export_key_internal(
  * \param[out] data_length      On success, the number of bytes written in
  *                              \p data
  *
- * \retval #PSA_SUCCESS  The public key was exported successfully.
+ * \retval #PSA_SUCCESS
+ *         The public key was exported successfully.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type is not supported.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure inside the implementation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the underlying hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key data was corrupted.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure that prevented the implementation from
+ *         exporting the key.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  */
 psa_status_t psa_export_public_key_internal(
     const psa_key_attributes_t *attributes,
@@ -364,6 +386,7 @@ psa_status_t psa_export_public_key_internal(
  * \retval #PSA_SUCCESS
  *         The key was generated successfully.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The key type is not supported or the key size is not valid.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         Key size in bits or type not supported.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
@@ -399,6 +422,7 @@ psa_status_t psa_generate_key_internal( const psa_key_attributes_t *attributes,
  *                              that make up the returned signature value.
  *
  * \retval #PSA_SUCCESS
+ *         The signature is valid.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p signature buffer is too small. You can
  *         determine a sufficient buffer size by calling
@@ -406,10 +430,16 @@ psa_status_t psa_generate_key_internal( const psa_key_attributes_t *attributes,
  *         where \c key_type and \c key_bits are the type and bit-size
  *         respectively of the key.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key_buffer is not a valid key buffer.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key data was corrupted.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is insufficient entropy to generate a signature that
+ *         satisfies the security requirements of the algorithm.
  */
 psa_status_t psa_sign_message_builtin(
     const psa_key_attributes_t *attributes,
@@ -445,8 +475,11 @@ psa_status_t psa_sign_message_builtin(
  *         The calculation was performed successfully, but the passed
  *         signature is not a valid signature.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key_buffer is not a valid key buffer.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  */
 psa_status_t psa_verify_message_builtin(
     const psa_key_attributes_t *attributes,
@@ -475,6 +508,7 @@ psa_status_t psa_verify_message_builtin(
  *                              that make up the returned signature value.
  *
  * \retval #PSA_SUCCESS
+ *         The signature is valid.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p signature buffer is too small. You can
  *         determine a sufficient buffer size by calling
@@ -482,10 +516,16 @@ psa_status_t psa_verify_message_builtin(
  *         where \c key_type and \c key_bits are the type and bit-size
  *         respectively of the key.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key_buffer is not a valid key buffer.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key data was corrupted.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is insufficient entropy to generate a signature that
+ *         satisfies the security requirements of the algorithm.
  */
 psa_status_t psa_sign_hash_builtin(
     const psa_key_attributes_t *attributes,
@@ -519,8 +559,11 @@ psa_status_t psa_sign_hash_builtin(
  *         The calculation was performed successfully, but the passed
  *         signature is not a valid signature.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p key_buffer is not a valid key buffer.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  */
 psa_status_t psa_verify_hash_builtin(
     const psa_key_attributes_t *attributes,

--- a/mbedtls/library/psa_crypto_driver_wrappers.c
+++ b/mbedtls/library/psa_crypto_driver_wrappers.c
@@ -427,8 +427,13 @@ psa_status_t psa_driver_wrapper_verify_hash(
  * \param[out] key_buffer_size  Minimum buffer size to contain the key material.
  *
  * \retval #PSA_SUCCESS
+ *         The minimum size for a buffer to contain the key material has been
+ *         returned successfully.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The key is declared with a lifetime not known to us.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The type and/or the size in bits of the key or the combination of
+ *         the two is not supported.
  */
 psa_status_t psa_driver_wrapper_get_key_buffer_size_from_key_data(
     const psa_key_attributes_t *attributes,

--- a/mbedtls/library/psa_crypto_ecp.h
+++ b/mbedtls/library/psa_crypto_ecp.h
@@ -67,12 +67,16 @@ psa_status_t mbedtls_psa_ecp_load_representation( psa_key_type_t type,
  *                                key_buffer in bytes.
  * \param[out] bits             The key size in number of bits.
  *
- * \retval #PSA_SUCCESS  The ECP key was imported successfully.
+ * \retval #PSA_SUCCESS
+ *         The ECP key was imported successfully.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The key data is not correctly formatted.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified key type is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal error.
  */
 psa_status_t mbedtls_psa_ecp_import_key(
     const psa_key_attributes_t *attributes,
@@ -110,13 +114,21 @@ psa_status_t mbedtls_psa_ecp_export_key( psa_key_type_t type,
  * \param[out] data_length      On success, the number of bytes written in
  *                              \p data
  *
- * \retval #PSA_SUCCESS  The ECP public key was exported successfully.
+ * \retval #PSA_SUCCESS
+ *         The ECP public key was exported successfully.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified key type is not supported.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure inside the implementation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the underlying hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption failure inside the implementation.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure that prevented the implementation from
+ *         accessing the key.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  */
 psa_status_t mbedtls_psa_ecp_export_public_key(
     const psa_key_attributes_t *attributes,
@@ -167,16 +179,23 @@ psa_status_t mbedtls_psa_ecp_generate_key(
  *                              that make up the returned signature value.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p signature buffer is too small. You can
  *         determine a sufficient buffer size by calling
  *         #PSA_SIGN_OUTPUT_SIZE(\c PSA_KEY_TYPE_ECC_KEY_PAIR, \c key_bits,
  *         \p alg) where \c key_bits is the bit-size of the ECC key.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The key type is not an ECDSA key pair.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a corruption failure inside the implementation.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is insufficient entropy to generate random data needed for
+ *         the requested operation.
  */
 psa_status_t mbedtls_psa_ecdsa_sign_hash(
     const psa_key_attributes_t *attributes,
@@ -210,8 +229,11 @@ psa_status_t mbedtls_psa_ecdsa_sign_hash(
  *         The calculation was performed successfully, but the passed
  *         signature is not a valid signature.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The specified algorithm is not supported.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The key type is not an ECDSA key pair.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  */
 psa_status_t mbedtls_psa_ecdsa_verify_hash(
     const psa_key_attributes_t *attributes,

--- a/mbedtls/library/psa_crypto_hash.h
+++ b/mbedtls/library/psa_crypto_hash.h
@@ -58,7 +58,9 @@ const mbedtls_md_info_t *mbedtls_md_info_from_psa( psa_algorithm_t alg );
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         \p hash_size is too small
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_hash_compute(
     psa_algorithm_t alg,
@@ -98,7 +100,9 @@ psa_status_t mbedtls_psa_hash_compute(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_hash_setup(
     mbedtls_psa_hash_operation_t *operation,
@@ -125,12 +129,15 @@ psa_status_t mbedtls_psa_hash_setup(
  *                                  It must be initialized but not active.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_BAD_STATE
  *         The \p source_operation state is not valid (it must be active).
  * \retval #PSA_ERROR_BAD_STATE
  *         The \p target_operation state is not valid (it must be inactive).
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  */
 psa_status_t mbedtls_psa_hash_clone(
     const mbedtls_psa_hash_operation_t *source_operation,
@@ -157,7 +164,9 @@ psa_status_t mbedtls_psa_hash_clone(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_hash_update(
     mbedtls_psa_hash_operation_t *operation,
@@ -196,7 +205,9 @@ psa_status_t mbedtls_psa_hash_update(
  *         sufficient buffer size by calling #PSA_HASH_LENGTH(\c alg)
  *         where \c alg is the hash algorithm that is calculated.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_hash_finish(
     mbedtls_psa_hash_operation_t *operation,
@@ -226,7 +237,9 @@ psa_status_t mbedtls_psa_hash_finish(
  * \param[in,out] operation     Initialized hash operation.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_hash_abort(
     mbedtls_psa_hash_operation_t *operation );

--- a/mbedtls/library/psa_crypto_mac.h
+++ b/mbedtls/library/psa_crypto_mac.h
@@ -53,7 +53,9 @@
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         \p mac_size is too small
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_mac_compute(
     const psa_key_attributes_t *attributes,
@@ -90,7 +92,9 @@ psa_status_t mbedtls_psa_mac_compute(
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  */
@@ -125,7 +129,9 @@ psa_status_t mbedtls_psa_mac_sign_setup(
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         \p alg is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive).
  */
@@ -159,7 +165,9 @@ psa_status_t mbedtls_psa_mac_verify_setup(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_mac_update(
     mbedtls_psa_mac_operation_t *operation,
@@ -201,7 +209,9 @@ psa_status_t mbedtls_psa_mac_update(
  *         The size of the \p mac buffer is too small. A sufficient buffer size
  *         can be determined by calling PSA_MAC_LENGTH().
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_mac_sign_finish(
     mbedtls_psa_mac_operation_t *operation,
@@ -242,7 +252,9 @@ psa_status_t mbedtls_psa_mac_sign_finish(
  *         The operation state is not valid (it must be an active mac verify
  *         operation).
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was not enough memory for the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_mac_verify_finish(
     mbedtls_psa_mac_operation_t *operation,
@@ -268,7 +280,9 @@ psa_status_t mbedtls_psa_mac_verify_finish(
  * \param[in,out] operation Initialized MAC operation.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was an internal memory corruption.
  */
 psa_status_t mbedtls_psa_mac_abort(
     mbedtls_psa_mac_operation_t *operation );

--- a/mbedtls/library/psa_crypto_rsa.h
+++ b/mbedtls/library/psa_crypto_rsa.h
@@ -58,12 +58,16 @@ psa_status_t mbedtls_psa_rsa_load_representation( psa_key_type_t type,
  *                                key_buffer in bytes.
  * \param[out] bits             The key size in number of bits.
  *
- * \retval #PSA_SUCCESS  The RSA key was imported successfully.
+ * \retval #PSA_SUCCESS
+ *         The RSA key was imported successfully.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The key data is not correctly formatted.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type is not supported.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key data is not correctly formatted.
  */
 psa_status_t mbedtls_psa_rsa_import_key(
     const psa_key_attributes_t *attributes,
@@ -101,13 +105,21 @@ psa_status_t mbedtls_psa_rsa_export_key( psa_key_type_t type,
  * \param[out] data_length      On success, the number of bytes written in
  *                              \p data.
  *
- * \retval #PSA_SUCCESS  The RSA public key was exported successfully.
+ * \retval #PSA_SUCCESS
+ *         The RSA public key was exported successfully.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type is not supported.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ *         There was a communication failure inside the implementation.
  * \retval #PSA_ERROR_HARDWARE_FAILURE
+ *         There was a failure in the underlying hardware.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key data is not correctly formatted.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a storage failure that prevented the implementation from
+ *         accessing the key.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  */
 psa_status_t mbedtls_psa_rsa_export_public_key(
     const psa_key_attributes_t *attributes,
@@ -159,16 +171,23 @@ psa_status_t mbedtls_psa_rsa_generate_key(
  *                              that make up the returned signature value.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p signature buffer is too small. You can
  *         determine a sufficient buffer size by calling
  *         #PSA_SIGN_OUTPUT_SIZE(\c PSA_KEY_TYPE_RSA_KEY_PAIR, \c key_bits,
  *         \p alg) where \c key_bits is the bit-size of the RSA key.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p alg is not supported or is not compatible with the key type.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The specified hash algorithm is not supported or is not compatible
+ *         with the specified key type.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         There was a failure in the underlying hardware.
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ *         There is insufficient entropy to generate the key material.
  */
 psa_status_t mbedtls_psa_rsa_sign_hash(
     const psa_key_attributes_t *attributes,
@@ -203,8 +222,12 @@ psa_status_t mbedtls_psa_rsa_sign_hash(
  *         The calculation was performed successfully, but the passed
  *         signature is not a valid signature.
  * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p alg is not supported or is not compatible with the key type.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The specified hash algorithm is not supported or is not compatible
+ *         with the specified key type.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to perform the operation.
  */
 psa_status_t mbedtls_psa_rsa_verify_hash(
     const psa_key_attributes_t *attributes,

--- a/mbedtls/library/psa_crypto_slot_management.h
+++ b/mbedtls/library/psa_crypto_slot_management.h
@@ -89,8 +89,14 @@ static inline int psa_key_id_is_volatile( psa_key_id_t key_id )
  * \retval #PSA_ERROR_DOES_NOT_EXIST
  *         There is no key with key identifier \p key.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ *         The key slot lock counter reached its maximum value and was not
+ *         increased.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         \p key is a persistent key identifier. The key exists in storage
+ *         but could not be loaded.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         \p key is a persistent key identifier. The key exists in storage
+ *         but its data is corrupted.
  */
 psa_status_t psa_get_and_lock_key_slot( mbedtls_svc_key_id_t key,
                                         psa_key_slot_t **p_slot );
@@ -119,8 +125,12 @@ void psa_wipe_all_key_slots( void );
  * \param[out] p_slot            On success, a pointer to the slot.
  *
  * \retval #PSA_SUCCESS
+ *         \p *p_slot contains a pointer to a key slot that is available for
+ *         use and is in its ground state.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There is no available key slot.
  * \retval #PSA_ERROR_BAD_STATE
+ *         The library has not been initialized.
  */
 psa_status_t psa_get_empty_key_slot( psa_key_id_t *volatile_key_id,
                                      psa_key_slot_t **p_slot );
@@ -195,7 +205,9 @@ static inline int psa_key_lifetime_is_external( psa_key_lifetime_t lifetime )
  *                          associated with the key's storage location.
  *
  * \retval #PSA_SUCCESS
+ *         The key's location is valid.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The key's location is invalid.
  */
 psa_status_t psa_validate_key_location( psa_key_lifetime_t lifetime,
                                         psa_se_drv_table_entry_t **p_drv );
@@ -205,8 +217,9 @@ psa_status_t psa_validate_key_location( psa_key_lifetime_t lifetime,
  * \param[in] lifetime  The key lifetime attribute.
  *
  * \retval #PSA_SUCCESS
- * \retval #PSA_ERROR_NOT_SUPPORTED The key is persistent but persistent keys
- *             are not supported.
+ *         The key is not persistent or persistent keys are supported.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key is persistent but persistent keys are not supported.
  */
 psa_status_t psa_validate_key_persistence( psa_key_lifetime_t lifetime );
 

--- a/mbedtls/library/psa_crypto_storage.c
+++ b/mbedtls/library/psa_crypto_storage.c
@@ -86,10 +86,15 @@ static psa_storage_uid_t psa_its_identifier_of_slot( mbedtls_svc_key_id_t key )
  * \param data_size         Size of the \c data buffer in bytes.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The data is not a valid key.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The data is not a valid key.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The data could not be read from storage.
  * \retval #PSA_ERROR_DOES_NOT_EXIST
+ *         There is no data stored for this key.
  */
 static psa_status_t psa_crypto_storage_load(
     const mbedtls_svc_key_id_t key, uint8_t *data, size_t data_size )
@@ -135,10 +140,15 @@ int psa_is_key_present_in_storage( const mbedtls_svc_key_id_t key )
  *                      that make up the data.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There is not enough storage space to store the key.
  * \retval #PSA_ERROR_ALREADY_EXISTS
+ *         There is already data stored for this key.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The data could not be written to storage.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The data is not a valid key.
  */
 static psa_status_t psa_crypto_storage_store( const mbedtls_svc_key_id_t key,
                                               const uint8_t *data,
@@ -209,9 +219,13 @@ psa_status_t psa_destroy_persistent_key( const mbedtls_svc_key_id_t key )
  * \param[out] data_length  The number of bytes that make up the data.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         The data could not be read from storage.
  * \retval #PSA_ERROR_DOES_NOT_EXIST
+ *         There is no data stored for this key.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The data is not a valid key.
  */
 static psa_status_t psa_crypto_storage_get_data_length(
     const mbedtls_svc_key_id_t key,

--- a/mbedtls/library/psa_crypto_storage.h
+++ b/mbedtls/library/psa_crypto_storage.h
@@ -97,13 +97,21 @@ int psa_is_key_present_in_storage( const mbedtls_svc_key_id_t key );
  * \param data_length       The number of bytes that make up the key data.
  *
  * \retval #PSA_SUCCESS
+ *         The key was successfully saved.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The key data buffer is NULL or zero-length.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to save the key.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There was insufficient storage space to save the key.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in the underlying storage system.
  * \retval #PSA_ERROR_ALREADY_EXISTS
+ *         There is already a key in the given slot.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data was corrupted.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The key data was invalid.
  */
 psa_status_t psa_save_persistent_key( const psa_core_key_attributes_t *attr,
                                       const uint8_t *data,
@@ -130,10 +138,15 @@ psa_status_t psa_save_persistent_key( const psa_core_key_attributes_t *attr,
  * \param[out] data_length  The number of bytes that make up the key data.
  *
  * \retval #PSA_SUCCESS
+ *         The key was successfully loaded.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to load the key.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data was corrupted.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The key data was invalid.
  * \retval #PSA_ERROR_DOES_NOT_EXIST
+ *         There is no key in the given slot.
  */
 psa_status_t psa_load_persistent_key( psa_core_key_attributes_t *attr,
                                       uint8_t **data,
@@ -149,6 +162,7 @@ psa_status_t psa_load_persistent_key( psa_core_key_attributes_t *attr,
  *         The key was successfully removed,
  *         or the key did not exist.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data was corrupted.
  */
 psa_status_t psa_destroy_persistent_key( const mbedtls_svc_key_id_t key );
 
@@ -191,8 +205,11 @@ void psa_format_key_data_for_storage( const uint8_t *data,
  *                             with the loaded key metadata.
  *
  * \retval #PSA_SUCCESS
+ *         The key was successfully loaded.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *         There was insufficient memory to load the key.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The key data was corrupted.
  */
 psa_status_t psa_parse_key_data_from_storage( const uint8_t *storage_data,
                                               size_t storage_data_length,
@@ -326,9 +343,13 @@ static inline void psa_crypto_prepare_transaction(
  * atomically update the transaction state.
  *
  * \retval #PSA_SUCCESS
+ *         The transaction data has been saved to storage.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The transaction data in memory is invalid.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There is not enough space in storage to save the transaction data.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in the underlying storage system.
  */
 psa_status_t psa_crypto_save_transaction( void );
 
@@ -343,8 +364,11 @@ psa_status_t psa_crypto_save_transaction( void );
  * \retval #PSA_ERROR_DOES_NOT_EXIST
  *         There is no ongoing transaction.
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in the underlying storage system.
  * \retval #PSA_ERROR_DATA_INVALID
+ *         The transaction data in storage is invalid.
  * \retval #PSA_ERROR_DATA_CORRUPT
+ *         The transaction data in storage is invalid.
  */
 psa_status_t psa_crypto_load_transaction( void );
 
@@ -384,7 +408,9 @@ psa_status_t psa_crypto_stop_transaction( void );
  * \retval #PSA_SUCCESS
  *         Success
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         There was a failure in the underlying storage system.
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ *         There was insufficient storage space to save the entropy.
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         The entropy seed file already exists.
  */

--- a/source/Info.plist
+++ b/source/Info.plist
@@ -30,7 +30,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.53</string>
 	<key>CFBundleSignature</key>
-	<string>????</string>
+	<string>UNHn</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
- Set up project languages manually to prevent compiler's wrong guesses.
- Set up current platform explicitly for mac (both Intel and Apple Silicone) is automated now (old argument method doesn't worked for me).
- Fixed a lot of warnings, mostly with PSA crypto documentation.

*Was forced to fix warnings because there is a -Werror flag enabled.

I'm not certain that the fixes is complete. Although with this fixes I can now build the app, the Info.plist within it is merely a placeholder (I assume it should be changed in the build process). The application only functions correctly after manual adjustments. Can anyone assist with this issue? Though, I'm not sure if this is entirely relevant to my PR.