### PR TITLE
Showing the `Editor Versions/Install New` button on Linux

### DIFF
--- a/source/interface_derived.cpp
+++ b/source/interface_derived.cpp
@@ -94,9 +94,6 @@ MainFrameDerived::MainFrameDerived() : MainFrame(NULL){
 	if (status != 0){
 		ReloadData();
 	}
-	#if defined __linux__
-	launchHubBtn->Hide();
-	#endif
 
 	//if no projects to load, the interface will be blank
 


### PR DESCRIPTION
I don't get why this was hidden in the first place. It works just fine on my Arch system and functions the same as on my Windows machine, just opens the editor archive site.